### PR TITLE
Update CopyZips to use python3.6

### DIFF
--- a/templates/aspect-wfm-ap-kda.template
+++ b/templates/aspect-wfm-ap-kda.template
@@ -151,7 +151,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.6
       Role: !GetAtt 'CopyZipsRole.Arn'
       Timeout: 240
       Code:

--- a/templates/aspect-wfm-rta.template
+++ b/templates/aspect-wfm-rta.template
@@ -89,7 +89,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.6
       Role: !GetAtt 'CopyZipsRole.Arn'
       Timeout: 240
       Code:


### PR DESCRIPTION
Updating CopyZips functions to use the Python 3.6 runtime.

*Issue #10 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
