### PR TITLE
Update CopyZips Lambdas to Python 3.8

### DIFF
--- a/templates/aspect-wfm-ap-kda.template.yaml
+++ b/templates/aspect-wfm-ap-kda.template.yaml
@@ -182,7 +182,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.8
       Role: !GetAtt 'CopyZipsRole.Arn'
       Timeout: 240
       Code:
@@ -585,7 +585,7 @@ Resources:
           kda_application_name:
             Ref: KinesisDataAnalyticsApplication
       Handler: update.lambda_handler
-      Runtime: python3.6
+      Runtime: python3.8
       Role:
         Fn::GetAtt: LambdaRole.Arn
   LambdaVersion:

--- a/templates/aspect-wfm-rta.template.yaml
+++ b/templates/aspect-wfm-rta.template.yaml
@@ -203,7 +203,7 @@ Resources:
     Properties:
       Description: Copies objects from a source S3 bucket to a destination
       Handler: index.handler
-      Runtime: python2.7
+      Runtime: python3.8
       Role: !GetAtt 'CopyZipsRole.Arn'
       Timeout: 240
       Code:


### PR DESCRIPTION
*Description of changes:*
Update CopyZips Lambdas from Python 2.7 to Python 3.8
Update AP Lambda from Python 3.6 to Python 3.8


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
