### PR TITLE
Update to python 3.9

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -1,0 +1,1 @@
+language_type: cloudformation

--- a/templates/aspect-wfm-ap-kda.template.yaml
+++ b/templates/aspect-wfm-ap-kda.template.yaml
@@ -498,7 +498,7 @@ Resources:
           kda_application_name:
             Ref: KinesisDataAnalyticsApplication
       Handler: update.lambda_handler
-      Runtime: python3.6
+      Runtime: python3.9
       Role:
         Fn::GetAtt: LambdaRole.Arn
   LambdaVersion:


### PR DESCRIPTION
Update AP Lambda from python 3.6 to python 3.9.

*Description of changes:*
Update Lambda based on Python 3.6 EOL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
